### PR TITLE
Fix requirements and imports

### DIFF
--- a/fix_track_paths.sh
+++ b/fix_track_paths.sh
@@ -4,7 +4,7 @@
 source $(dirname $0)/python_tools/fix_track_paths_utils/config.sh
 
 # generating the custom database
-python3 $(dirname $0)/python_tools/fix_track_paths.py
+python -m python_tools.fix_track_paths
 test $? -ne 0 && exit
 
 if test -f "$custom_db"; then

--- a/mixxx_to_rekordbox.sh
+++ b/mixxx_to_rekordbox.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python python_tools/mixxx_to_rekordbox.py
+python -m python_tools.mixxx_to_rekordbox

--- a/python_tools/fix_track_paths.py
+++ b/python_tools/fix_track_paths.py
@@ -1,4 +1,6 @@
-from fix_track_paths_utils.clementine_custom_music_db import fix_with_clementine_db
+from python_tools.fix_track_paths_utils.clementine_custom_music_db import (
+    fix_with_clementine_db,
+)
 
 
 if __name__ == "__main__":

--- a/python_tools/fix_track_paths_utils/clementine_custom_music_db.py
+++ b/python_tools/fix_track_paths_utils/clementine_custom_music_db.py
@@ -2,13 +2,13 @@ from pathlib import Path
 from sys import exit
 
 import pandas as pd
-from utils.music_db_utils import file_url_to_path
-from utils.music_db_utils import MERGE_COLS
-from utils.music_db_utils import open_mixxx_library
-from utils.music_db_utils import open_table_as_df
-from utils.music_db_utils import write_df_to_table
-from utils.track_utils import get_closest_matches_indices
-from utils.track_utils import remove_feat
+from python_tools.utils.music_db_utils import file_url_to_path
+from python_tools.utils.music_db_utils import MERGE_COLS
+from python_tools.utils.music_db_utils import open_mixxx_library
+from python_tools.utils.music_db_utils import open_table_as_df
+from python_tools.utils.music_db_utils import write_df_to_table
+from python_tools.utils.track_utils import get_closest_matches_indices
+from python_tools.utils.track_utils import remove_feat
 
 from .config import CLEM_DB
 from .config import CUSTOM_DB

--- a/python_tools/mixxx_to_rekordbox.py
+++ b/python_tools/mixxx_to_rekordbox.py
@@ -1,27 +1,26 @@
 import logging
 import sys
 from pathlib import Path
-from shutil import copyfile
 from typing import Generator
 from urllib.parse import quote
 from xml.etree import ElementTree as ET
 
-import mixxx_to_rekordbox_utils.config as cfg
+import python_tools.mixxx_to_rekordbox_utils.config as cfg
 import pandas as pd
-from mixxx_to_rekordbox_utils.encoder_tools import get_offset_ms
-from mixxx_to_rekordbox_utils.xml_utils import AttribDict
-from mixxx_to_rekordbox_utils.xml_utils import get_elem
+from python_tools.mixxx_to_rekordbox_utils.encoder_tools import get_offset_ms
+from python_tools.mixxx_to_rekordbox_utils.xml_utils import AttribDict
+from python_tools.mixxx_to_rekordbox_utils.xml_utils import get_elem
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
-from utils.key_utils import key_id_to_lancelot
-from utils.misc import confirm_config
-from utils.music_db_utils import open_mixxx_cues
-from utils.music_db_utils import open_mixxx_library
-from utils.music_db_utils import open_mixxx_playlists_with_tracks
-from utils.music_db_utils import open_mixxx_track_locations
-from utils.track_utils import BeatGridInfo
-from utils.track_utils import guess_inizio_sec
-from utils.track_utils import position_frame_to_sec
+from python_tools.utils.key_utils import key_id_to_lancelot
+from python_tools.utils.misc import confirm_config
+from python_tools.utils.music_db_utils import open_mixxx_cues
+from python_tools.utils.music_db_utils import open_mixxx_library
+from python_tools.utils.music_db_utils import open_mixxx_playlists_with_tracks
+from python_tools.utils.music_db_utils import open_mixxx_track_locations
+from python_tools.utils.track_utils import BeatGridInfo
+from python_tools.utils.track_utils import guess_inizio_sec
+from python_tools.utils.track_utils import position_frame_to_sec
 
 
 # 0 star = "0", 1 star = "51", 2 stars = "102", 3 stars = "153", 4 stars = "204", 5 stars = "255"

--- a/python_tools/requirements-pip-dev.txt
+++ b/python_tools/requirements-pip-dev.txt
@@ -1,0 +1,6 @@
+-r requirements-pip.txt
+
+types-protobuf
+pandas-stubs
+types-tqdm
+pre-commit

--- a/python_tools/requirements-pip.txt
+++ b/python_tools/requirements-pip.txt
@@ -1,3 +1,6 @@
 eyed3>=0.9
 protobuf
-types-protobuf
+pandas
+jellyfish
+tqdm
+sqlalchemy

--- a/python_tools/snap_cues/snap_cues.py
+++ b/python_tools/snap_cues/snap_cues.py
@@ -1,26 +1,19 @@
-from pathlib import Path
-from sys import path
-
 from tqdm import tqdm
 
-path.append(Path(__file__).parent.parent.as_posix())  # ugly tricks but works fine :-p
-
-from utils.music_db_utils import (
+from python_tools.utils.music_db_utils import (
     open_mixxx_library,
     open_mixxx_cues,
     write_df_to_table,
 )
 
-from utils.track_utils import (
+from python_tools.utils.track_utils import (
     BeatGridInfo,
-    position_frame_to_sec,
-    position_sec_to_frame,
     snap_cue_frame,
 )
 
-from utils.misc import confirm_config
+from python_tools.utils.misc import confirm_config
 
-import config as cfg
+import python_tools.snap_cues.config as cfg
 
 
 if __name__ == "__main__":

--- a/snap_cues.sh
+++ b/snap_cues.sh
@@ -4,7 +4,7 @@
 source python_tools/snap_cues/config.sh
 
 # generating the custom database
-python3 python_tools/snap_cues/snap_cues.py || exit
+python3 -m python_tools.snap_cues.snap_cues || exit
 
 if test -f "$custom_db"; then
 


### PR DESCRIPTION
- Add missing requirements for pip and also create a separate requirements file for dev requirements (such as stubs an pre-commit)
- Make all imports absolute in Python modules and call the scripts using `python -m` so that the imports work without having to tinker with paths