### PR TITLE
Make mixxx-utils configurable via a toml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+config.toml

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ I can totally do it, but unless someone shows an interest, Im going to play the 
 **IMPORTANT**: As of May 4th 2024, Mixxx's database needs to be fixed so the Python tools work.
 Please see the[fix_mixxx_db.md](fix_mixxx_db.md) file.
 
+<<<<<<< HEAD
 **NOTE TO DEVELOPERS #1**: There is an additionnal requirements file (`python_tools/requirements-pip-dev.txt`).
 After installing the requirements, please run `pre-commit install` to prepare the differents "hooks" that will be executed when you commit stuff.
 **Watch out** as one hooks enforces to not commit on the `main` branch so start by create a branch to work in it!
@@ -16,6 +17,17 @@ After installing the requirements, please run `pre-commit install` to prepare th
 **NOTE TO DEVELOPERS #2**: Using [pyrekordbox](https://pyrekordbox.readthedocs.io) to write directly into Rekordbox pdb file instead of using 
 an intermediate step with an XML file would be neat for people without dual-boot. If you're interested in participating, please let me know, 
 as I don't have much incentive to do it for myself.
+=======
+**NOTE TO DEVELOPERS**: There is an additionnal requirements file (`python_tools/requirements-pip-dev.txt`).
+After installing the requirements, please run `pre-commit install` to prepare the differents "hooks" that will be executed when you commit stuff.
+**Watch out** as one hooks enforces to not commit on the `main` branch so start by create a branch to work in it!
+
+## Configuration
+
+The different tools get their configuration from a toml file that is specified through the
+MIXXX_UTILS_CONFIG environment variable or will default to a file named `config.toml` in the
+current directory. See the provided `example.config.toml` for details.
+>>>>>>> 77a9421 (Make mixxx-utils configurable via a toml file)
 
 ## Python tools
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,0 +1,36 @@
+[mixxx]
+
+mixxx_db = "/home/benselme/.mixxx/mixxxdb.sqlite"
+mixxx_folder = "/home/benselme/.mixxx/"
+
+[mixxx_to_rekordbox]
+rekordbox_xml_file = "rekordbox_output.xml"
+mixxx_library_folder = "/mnt/data/mixxx_test"
+rekordbox_library_folder = "E:/DNB"
+export_only_tracks_in_playlists = true
+
+crates_suffix = "_crates"
+add_crates_as_playlist = true
+beats_per_bar = 4
+index_cue_bar_start = 3
+mp3_decoder = "MAD"
+
+[snap_cues]
+
+custom_db = "/tmp/custom_music_db.sqlite"
+custom_db_table_name = "custom_table"
+idx_snapped_cues = [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+[fix_track_paths_utils]
+
+clem_db = "${HOME}/.config/Clementine/clementine.db"
+custom_db = "/tmp/custom_music_db.sqlite"
+custom_db_table_name = "custom_table"
+custom_db_library_idx_column = "MIXXX_LIBRARY_IDX"
+custom_db_location_idx_column = "MIXXX_LOCATION_IDX"
+custom_db_path_column = "MUSIC_PLAYER_PATH"
+custom_db_filename_column = "MUSIC_PLAYER_FILENAME"
+custom_db_directory_column = "MUSIC_PLAYER_DIRECTORY"
+threshold_name_similarity = 50
+n_similar_track_proposal = 3

--- a/python_tools/__init__.py
+++ b/python_tools/__init__.py
@@ -1,1 +1,24 @@
-# -*- coding: utf-8 -*-
+import sys
+from pathlib import Path
+import os
+import tomllib
+from typing import Any
+
+
+def get_config() -> dict[str, Any]:
+    try:
+        config_filename = os.environ["MIXXX_UTILS_CONFIG"]
+        config_path = Path(config_filename)
+    except KeyError:
+        config_path = Path.cwd() / "config.toml"
+
+    if not config_path.exists():
+        msg = (
+            "Could not find config, it should either be a file named config.toml"
+            "in the current directory or its path should be specified in the "
+            "MIXXX_UTILS_CONFIG environment variable"
+        )
+        print(msg)
+        sys.exit(1)
+
+    return tomllib.loads(config_path.read_text())

--- a/python_tools/fix_track_paths_utils/config.py
+++ b/python_tools/fix_track_paths_utils/config.py
@@ -1,14 +1,19 @@
+from python_tools import get_config
+
 # parameters for clementine_custom_music_db.py
 # (Fixing tracks locations)
 # The names MUST correspond to the ones in fix_track_paths/mixxxdb_fix_tracks_locations.sql file
 # You normally do not need to change them
-CLEM_DB = "${HOME}/.config/Clementine/clementine.db"
-CUSTOM_DB = "/tmp/custom_music_db.sqlite"
-CUSTOM_DB_TABLE_NAME = "custom_table"
-CUSTOM_DB_LIBRARY_IDX_COLUMN = "MIXXX_LIBRARY_IDX"
-CUSTOM_DB_LOCATION_IDX_COLUMN = "MIXXX_LOCATION_IDX"
-CUSTOM_DB_PATH_COLUMN = "MUSIC_PLAYER_PATH"
-CUSTOM_DB_FILENAME_COLUMN = "MUSIC_PLAYER_FILENAME"
-CUSTOM_DB_DIRECTORY_COLUMN = "MUSIC_PLAYER_DIRECTORY"
-THRESHOLD_NAME_SIMILARITY: int = 50
-N_SIMILAR_TRACK_PROPOSAL: int = 3
+
+_config = get_config()["fix_track_paths_utils"]
+
+CLEM_DB = _config["clem_db"]
+CUSTOM_DB = _config["custom_db"]
+CUSTOM_DB_TABLE_NAME = _config["custom_db_table_name"]
+CUSTOM_DB_LIBRARY_IDX_COLUMN = _config["custom_db_library_idx_column"]
+CUSTOM_DB_LOCATION_IDX_COLUMN = _config["custom_db_location_idx_column"]
+CUSTOM_DB_PATH_COLUMN = _config["custom_db_path_column"]
+CUSTOM_DB_FILENAME_COLUMN = _config["custom_db_filename_column"]
+CUSTOM_DB_DIRECTORY_COLUMN = _config["custom_db_directory_column"]
+THRESHOLD_NAME_SIMILARITY: int = _config["threshold_name_similarity"]
+N_SIMILAR_TRACK_PROPOSAL: int = _config["n_similar_track_proposal"]

--- a/python_tools/mixxx_to_rekordbox.py
+++ b/python_tools/mixxx_to_rekordbox.py
@@ -69,19 +69,19 @@ def mixxx_track_and_cue_rows_to_rekbox_tempo_xml(
     bpm = trk_row["bpm"]
     assert isinstance(bpm, float)
     if (
-        cfg.index_cue_bar_start <= 0
-        or cfg.index_cue_bar_start - 1 not in cue_rows["hotcue"].values
+        cfg.INDEX_CUE_BAR_START <= 0
+        or cfg.INDEX_CUE_BAR_START - 1 not in cue_rows["hotcue"].values
     ):
         beatgrid_info = BeatGridInfo(trk_row)
         inizio = beatgrid_info.start_sec
     else:
-        cue_point = cue_rows[cfg.index_cue_bar_start - 1 == cue_rows["hotcue"]]
+        cue_point = cue_rows[cfg.INDEX_CUE_BAR_START - 1 == cue_rows["hotcue"]]
         if len(cue_point) != 1:
             logging.warning(
                 "More than one hotcue #%d has been found for file %s\n.",
                 "The first one has been kept to decide the start of the bars"
                 "… but you might want to re-create it!",
-                cfg.index_cue_bar_start,
+                cfg.INDEX_CUE_BAR_START,
                 trk_row["location"],
             )
             cue_point = cue_point[0]
@@ -89,13 +89,13 @@ def mixxx_track_and_cue_rows_to_rekbox_tempo_xml(
             cue_point.iloc[0]["position"],
             trk_row["samplerate"],
             bpm,
-            cfg.beats_per_bar,
+            cfg.BEATS_PER_BAR,
         )
 
     attrib: AttribDict = {
         "Inizio": inizio + offset_start_beatgrid_ms / 1000,
         "Bpm": bpm,
-        "Metro": f"{cfg.beats_per_bar}/{cfg.beats_per_bar}",
+        "Metro": f"{cfg.BEATS_PER_BAR}/{cfg.BEATS_PER_BAR}",
         "Battito": "1",
     }
     return get_elem("TEMPO", attrib)
@@ -104,9 +104,9 @@ def mixxx_track_and_cue_rows_to_rekbox_tempo_xml(
 def mixxx_track_row_to_rekbox_track_xml(trk_row: pd.Series) -> ET.Element:
     location = trk_row["location" + SUFFIX_LOC]
     final_location = location.replace(
-        cfg.mixxx_library_folder, cfg.rekordbox_library_folder
+        cfg.MIXXX_LIBRARY_FOLDER, cfg.REKORDBOX_LIBRARY_FOLDER
     )
-    if cfg.rekordbox_library_folder not in final_location:
+    if cfg.REKORDBOX_LIBRARY_FOLDER not in final_location:
         logging.warning("This track is not in the Mixxx library folder: %s", location)
 
     if not is_non_empty_string(trk_row["artist"]):
@@ -187,9 +187,9 @@ if __name__ == "__main__":
     # %% checking the config
     confirm_config(cfg)
 
-    if cfg.index_cue_bar_start != 0:
+    if cfg.INDEX_CUE_BAR_START != 0:
         print(
-            f"The hot cue #{cfg.index_cue_bar_start} will be used to detect the start of the bars."
+            f"The hot cue #{cfg.INDEX_CUE_BAR_START} will be used to detect the start of the bars."
         )
         answer = input(
             "Are you sure all these hot cues are snapped to the beatgrid (y/*)? : "
@@ -203,10 +203,10 @@ if __name__ == "__main__":
     df_cues = open_mixxx_cues(only_hot_cues=True)
     df_pls, df_pls_trk = open_mixxx_playlists_with_tracks(
         filter_hidden=True,
-        add_crates_as_playlist=cfg.add_crates_as_playlist,
-        crate_suffix=cfg.crates_suffix,
+        add_crates_as_playlist=cfg.ADD_CRATES_AS_PLAYLIST,
+        crate_suffix=cfg.CRATES_SUFFIX,
     )
-    if cfg.export_only_tracks_in_playlists:
+    if cfg.EXPORT_ONLY_TRACKS_IN_PLAYLISTS:
         df_lib = df_lib[df_lib["id"].isin(df_pls_trk["track_id"])]
 
     # Filter out tracks with "STEM" in comments
@@ -239,7 +239,7 @@ if __name__ == "__main__":
             track_cues = df_cues[df_cues["track_id"] == track_row["id" + SUFFIX_LIB]]
             rate = track_row["samplerate"]
             export_offset_ms = get_offset_ms(
-                track_row["location" + SUFFIX_LOC], cfg.mp3_decoder
+                track_row["location" + SUFFIX_LOC], cfg.MP3_DECODER
             )
             for _, cue_row in track_cues.iterrows():
                 assert rate
@@ -281,7 +281,7 @@ if __name__ == "__main__":
     tree = ET.ElementTree(element=root_xml)
     ET.indent(tree, space="  ", level=0)
 
-    rek_fil = Path(cfg.mixxx_library_folder, cfg.rekordbox_xml_file)
+    rek_fil = Path(cfg.MIXXX_LIBRARY_FOLDER, cfg.REKORDBOX_XML_FILE)
     with open(rek_fil, "w", encoding="utf-8") as fxml:
         fxml.write('<?xml version="1.0" encoding="UTF-8"?>')
     tree.write(rek_fil, encoding="unicode")

--- a/python_tools/mixxx_to_rekordbox_utils/config.py
+++ b/python_tools/mixxx_to_rekordbox_utils/config.py
@@ -1,11 +1,17 @@
 from typing import Final
 from typing import Literal
 
-rekordbox_xml_file: Final[str] = "rekordbox_output.xml"
+from python_tools import get_config
+
+_config = get_config()["mixxx_to_rekordbox"]
+
+REKORDBOX_XML_FILE: Final[str] = _config["rekordbox_xml_file"]
 # both can be the same if you use Mixxx on Windows =>
-mixxx_library_folder: Final[str] = "/home/francois/Musique/DNB"
-rekordbox_library_folder: Final[str] = "E:/DNB"
-export_only_tracks_in_playlists: Final[bool] = True
+MIXXX_LIBRARY_FOLDER: Final[str] = _config["mixxx_library_folder"]
+REKORDBOX_LIBRARY_FOLDER: Final[str] = _config["rekordbox_library_folder"]
+EXPORT_ONLY_TRACKS_IN_PLAYLISTS: Final[bool] = _config[
+    "export_only_tracks_in_playlists"
+]
 # Mixxx mp3 decoder
 # this is used to calculate the tracks offsets to apply when exporting to Rekordbox
 # The value can be: MAD, CoreAudio, FFmpeg
@@ -16,7 +22,7 @@ export_only_tracks_in_playlists: Final[bool] = True
 #  info [Main] SoundSourceProxy - 3 (default) : "MAD: MPEG Audio Decoder 0.15.1 (beta) NDEBUG FPM_64BIT"
 #  info [Main] SoundSourceProxy - 1 (lowest) : "FFmpeg 4.4.2-0ubuntu0.22.04.1"
 # The one with the highest probability is MAD
-mp3_decoder: Final[Literal["MAD", "CoreAudio", "FFmpeg"]] = "MAD"
+MP3_DECODER: Final[Literal["MAD", "CoreAudio", "FFmpeg"]] = _config["mp3_decoder"]
 # If one of your hot cue is always at the start of a bar (for example: a hot cue for the drop)
 # then we can use it to calculate the start of the bars
 # (some tracks do not start at the start of a bar so using the start of the beatgrid is incorrect)
@@ -25,8 +31,8 @@ mp3_decoder: Final[Literal["MAD", "CoreAudio", "FFmpeg"]] = "MAD"
 #  - if the hot cue does not exist, the start of the BeatGrid will be used
 #  - the hot cue must be exactly on the BeatGrid: the snap_cues utility is here to help you with that!
 #
-index_cue_bar_start: Final[int] = 3  #
-beats_per_bar: Final[int] = 4
+INDEX_CUE_BAR_START: Final[int] = _config["index_cue_bar_start"]  #
+BEATS_PER_BAR: Final[int] = _config["beats_per_bar"]
 #
-add_crates_as_playlist: Final[bool] = True
-crates_suffix: Final[str] = "_crate"
+ADD_CRATES_AS_PLAYLIST: Final[bool] = _config["add_crates_as_playlist"]
+CRATES_SUFFIX: Final[str] = _config["crates_suffix"]

--- a/python_tools/snap_cues/config.py
+++ b/python_tools/snap_cues/config.py
@@ -1,8 +1,14 @@
+from typing import Final
+
+from python_tools import get_config
+
+_config = get_config()["snap_cues"]
+
 # parameters for snap_cues.py
 # (Fixing tracks locations)
 # The names MUST correspond to the ones in mixxxdb_fix_cues.sql file
 # You normally do not need to change them
-CUSTOM_DB = "/tmp/custom_music_db.sqlite"
-CUSTOM_DB_TABLE_NAME = "custom_table"
+CUSTOM_DB: Final[str] = _config["custom_db"]
+CUSTOM_DB_TABLE_NAME: Final[str] = _config["custom_db_table_name"]
 # Cues index to modify
-IDX_SNAPPED_CUES = 1, 2, 3, 4, 5, 6, 7, 8
+IDX_SNAPPED_CUES: Final[list[int]] = _config["idx_snapped_cues"]

--- a/python_tools/utils/config.py
+++ b/python_tools/utils/config.py
@@ -1,2 +1,6 @@
-MIXXX_DB = "${HOME}/.mixxx/mixxxdb.sqlite"
-# MIXXX_FOLDER = "${HOME}/Mixxx/"  YAGNI
+from python_tools import get_config
+
+_config = get_config()["mixxx"]
+
+MIXXX_DB = _config["mixxx_db"]
+MIXXX_FOLDER = _config["mixxx_folder"]

--- a/python_tools/utils/misc.py
+++ b/python_tools/utils/misc.py
@@ -1,7 +1,7 @@
+import re
 from inspect import getmembers
 from sys import exit
 from types import ModuleType
-
 
 # 0 star = "0", 1 star = "51", 2 stars = "102", 3 stars = "153", 4 stars = "204", 5 stars = "255"
 RATING_MAPING = {0: 0, 1: 51, 2: 102, 3: 153, 4: 204, 5: 255}
@@ -38,9 +38,7 @@ KEY_ID_LANCELOT = {
 
 def confirm_config(config_module: ModuleType):
     members = getmembers(config_module)
-    params = sorted(
-        i for i in members if not i[0].startswith("__") and "." not in str(i[1])
-    )
+    params = sorted(i for i in members if re.match("^[A-Z][A-Z0-9_]+$", i[0]))
     if params:
         print(
             "The following parameters have been defined in the "


### PR DESCRIPTION
This allows updating the code without overwriting the various config.py files that are checked in git.

It's also the first step in my plan to make mixxx-utils installable via pip which will greatly simplify its use!

Next steps will be converting shell scripts to python (which will make life easier for Windows users as well), and swtiching to [uv](https://docs.astral.sh/uv/) for dependency management and building/publishing the package to PyPI.